### PR TITLE
Add api_key and api_secret to initial config, mangle app name on init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 WEBHOOK_URI=https://some.example.com/shop/example
-
+API_KEY=""
+API_SECRET=""

--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -92,6 +92,10 @@ for path in $paths; do
 done
 success "Done!\n"
 
+header "Updating Shopify initializers"
+run /usr/bin/sed -i "''" "s/$snakeCaseBefore/$snakeCaseAfter/g" lib/$snakeCaseAfter/shopify_api/initializer.ex
+success "Done!\n"
+
 header "Importing project README.md"
 run "rm README.md && mv BOILERPLATE_README.md README.md"
 success "Done!\n"

--- a/lib/shopify_app/shopify_api/initializer.ex
+++ b/lib/shopify_app/shopify_api/initializer.ex
@@ -10,9 +10,9 @@ defmodule ShopifyApp.ShopifyAPI.Initializer do
   def app_init do
     [
       %ShopifyAPIApp{
-        name: "",
-        client_id: "",
-        client_secret: "",
+        name: "shopify_app",
+        client_id: api_key: System.get_env("API_KEY"),
+        client_secret: System.get_env("API_SECRET"),
         auth_redirect_uri: "",
         nonce: "test",
         scope:


### PR DESCRIPTION
Make the app configuration a bit easier on init.

- Mangle the default app name to match the value passed in to boilerplate script.
- We now have env vars for api key and secret which are read by the default app.